### PR TITLE
feat: add managed daemon mode for tunn

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@
 - 🔌 **Multiple Ports**: Support for multiple port mappings per tunnel
 - 🔐 **SSH Integration**: Leverages your existing SSH configuration
 - ⚡ **Parallel Execution**: All tunnels run concurrently
+- 🧩 **Daemon Mode**: Background service with status reporting via IPC
 
 ## Installation
 
@@ -83,6 +84,33 @@ tunn api db
 tunn db cache
 ```
 
+### Run Tunnels in the Background
+
+```bash
+tunn --detach
+
+# Or only specific tunnels
+tunn --detach api db
+```
+
+The CLI respawns itself as a daemon, stores metadata under `$XDG_RUNTIME_DIR/tunn` (or `~/.cache/tunn` when the runtime dir is unavailable), and immediately returns control to the terminal.
+
+### Check Daemon Status
+
+```bash
+tunn status
+```
+
+The status command contacts the daemon's Unix socket, reporting the PID, mode, and the latest port states for each managed tunnel. If no daemon is running, a friendly message is printed instead.
+
+### Stop the Daemon
+
+```bash
+tunn stop
+```
+
+The stop command asks the daemon to shut down cleanly, waits for it to exit, and reports success.
+
 ### Output Example
 
 ```
@@ -117,3 +145,13 @@ Host database
 - Go 1.21 or higher (for building)
 - OpenSSH client (`ssh` command)
 - Valid SSH configuration
+
+## Daemon Runtime Files
+
+While running in detached mode, `tunn` stores the following files in its runtime directory:
+
+- `daemon.pid` – PID of the active daemon; used to prevent duplicate launches.
+- `daemon.sock` – Unix domain socket for control commands (e.g., `tunn status`).
+- `daemon.log` – Aggregated stdout/stderr from the daemon process.
+
+The directory is created with `0700` permissions, and files are cleaned up automatically when the daemon exits or when stale state is detected on the next launch.

--- a/README.md
+++ b/README.md
@@ -10,6 +10,9 @@
 - 🔐 **SSH Integration**: Leverages your existing SSH configuration
 - ⚡ **Parallel Execution**: All tunnels run concurrently
 - 🧩 **Daemon Mode**: Background service with status reporting via IPC
+- 🧼 **Lean Go Module**: Depends only on `gopkg.in/yaml.v3`, keeping builds clean and portable
+- 🔧 **Native SSH Sessions**: Spawns the system `ssh` binary for each mapping, so keys and config behave exactly like your shell
+- 🎚️ **Per-Port Processes**: Launches one PID per port to pave the way for fine-grained lifecycle controls
 
 ## Installation
 
@@ -145,6 +148,7 @@ Host database
 - Go 1.21 or higher (for building)
 - OpenSSH client (`ssh` command)
 - Valid SSH configuration
+- macOS and Linux are supported today; Windows support is planned but not available yet
 
 ## Daemon Runtime Files
 

--- a/cli/options.go
+++ b/cli/options.go
@@ -1,0 +1,88 @@
+package cli
+
+import (
+	"errors"
+	"fmt"
+)
+
+// Command represents the high-level action requested by the user.
+type Command int
+
+const (
+	CommandStart Command = iota
+	CommandStatus
+	CommandStop
+)
+
+// Options captures parsed CLI arguments.
+type Options struct {
+	Command        Command
+	Detach         bool
+	InternalDaemon bool
+	TunnelNames    []string
+}
+
+var (
+	errStatusWithDetach = errors.New("status command cannot be used with --detach")
+	errStatusWithArgs   = errors.New("status command does not accept tunnel names")
+	errStopWithDetach   = errors.New("stop command cannot be used with --detach")
+	errStopWithArgs     = errors.New("stop command does not accept tunnel names")
+)
+
+// Parse inspects the provided arguments and produces structured options.
+func Parse(args []string) (*Options, error) {
+	opts := &Options{Command: CommandStart}
+
+	for i := 0; i < len(args); i++ {
+		arg := args[i]
+		switch arg {
+		case "-d", "--detach":
+			if opts.Command == CommandStatus {
+				return nil, errStatusWithDetach
+			}
+			if opts.Command == CommandStop {
+				return nil, errStopWithDetach
+			}
+			opts.Detach = true
+		case "--internal-daemon":
+			opts.InternalDaemon = true
+		case "status":
+			if opts.Command != CommandStart {
+				return nil, fmt.Errorf("duplicate command")
+			}
+			if opts.Detach {
+				return nil, errStatusWithDetach
+			}
+			if len(opts.TunnelNames) > 0 {
+				return nil, errStatusWithArgs
+			}
+			opts.Command = CommandStatus
+		case "stop":
+			if opts.Command != CommandStart {
+				return nil, fmt.Errorf("duplicate command")
+			}
+			if opts.Detach {
+				return nil, errStopWithDetach
+			}
+			if len(opts.TunnelNames) > 0 {
+				return nil, errStopWithArgs
+			}
+			opts.Command = CommandStop
+		case "-h", "--help":
+			return nil, fmt.Errorf("usage: tunn [--detach|-d] [tunnel ...]\n       tunn status")
+		default:
+			if len(arg) > 0 && arg[0] == '-' {
+				return nil, fmt.Errorf("unknown flag: %s", arg)
+			}
+			if opts.Command == CommandStatus {
+				return nil, errStatusWithArgs
+			}
+			if opts.Command == CommandStop {
+				return nil, errStopWithArgs
+			}
+			opts.TunnelNames = append(opts.TunnelNames, arg)
+		}
+	}
+
+	return opts, nil
+}

--- a/cli/options_test.go
+++ b/cli/options_test.go
@@ -1,0 +1,108 @@
+package cli
+
+import "testing"
+
+func TestParse(t *testing.T) {
+	tests := []struct {
+		name      string
+		input     []string
+		want      Options
+		wantError string
+	}{
+		{
+			name:  "no args",
+			input: nil,
+			want:  Options{Command: CommandStart},
+		},
+		{
+			name:  "tunnel names",
+			input: []string{"db", "cache"},
+			want:  Options{Command: CommandStart, TunnelNames: []string{"db", "cache"}},
+		},
+		{
+			name:  "detach",
+			input: []string{"--detach", "db"},
+			want:  Options{Command: CommandStart, Detach: true, TunnelNames: []string{"db"}},
+		},
+		{
+			name:  "short detach",
+			input: []string{"-d"},
+			want:  Options{Command: CommandStart, Detach: true},
+		},
+		{
+			name:  "status",
+			input: []string{"status"},
+			want:  Options{Command: CommandStatus},
+		},
+		{
+			name:      "status with detach",
+			input:     []string{"status", "--detach"},
+			wantError: errStatusWithDetach.Error(),
+		},
+		{
+			name:      "status with args",
+			input:     []string{"status", "foo"},
+			wantError: errStatusWithArgs.Error(),
+		},
+		{
+			name:  "internal daemon",
+			input: []string{"--internal-daemon"},
+			want:  Options{Command: CommandStart, InternalDaemon: true},
+		},
+		{
+			name:  "stop",
+			input: []string{"stop"},
+			want:  Options{Command: CommandStop},
+		},
+		{
+			name:      "stop with detach",
+			input:     []string{"stop", "-d"},
+			wantError: errStopWithDetach.Error(),
+		},
+		{
+			name:      "stop with args",
+			input:     []string{"stop", "db"},
+			wantError: errStopWithArgs.Error(),
+		},
+		{
+			name:      "unknown flag",
+			input:     []string{"--unknown"},
+			wantError: "unknown flag: --unknown",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := Parse(tt.input)
+			if tt.wantError != "" {
+				if err == nil {
+					t.Fatalf("expected error %q, got nil", tt.wantError)
+				}
+				if err.Error() != tt.wantError {
+					t.Fatalf("expected error %q, got %q", tt.wantError, err.Error())
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got.Command != tt.want.Command {
+				t.Fatalf("command mismatch: got %v want %v", got.Command, tt.want.Command)
+			}
+			if got.Detach != tt.want.Detach {
+				t.Fatalf("detach mismatch: got %v want %v", got.Detach, tt.want.Detach)
+			}
+			if got.InternalDaemon != tt.want.InternalDaemon {
+				t.Fatalf("internal daemon mismatch: got %v want %v", got.InternalDaemon, tt.want.InternalDaemon)
+			}
+			if len(got.TunnelNames) != len(tt.want.TunnelNames) {
+				t.Fatalf("tunnel names length mismatch: got %d want %d", len(got.TunnelNames), len(tt.want.TunnelNames))
+			}
+			for i, v := range got.TunnelNames {
+				if v != tt.want.TunnelNames[i] {
+					t.Fatalf("tunnel name %d mismatch: got %s want %s", i, v, tt.want.TunnelNames[i])
+				}
+			}
+		})
+	}
+}

--- a/daemon/client.go
+++ b/daemon/client.go
@@ -1,0 +1,40 @@
+package daemon
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net"
+)
+
+func sendRequest(ctx context.Context, paths Paths, command string) (*StatusResponse, error) {
+	dialer := net.Dialer{}
+	conn, err := dialer.DialContext(ctx, "unix", paths.SocketFile)
+	if err != nil {
+		return nil, fmt.Errorf("failed to connect to daemon socket: %w", err)
+	}
+	defer conn.Close()
+
+	encoder := json.NewEncoder(conn)
+	decoder := json.NewDecoder(conn)
+
+	if err := encoder.Encode(StatusRequest{Command: command}); err != nil {
+		return nil, fmt.Errorf("failed to send %s request: %w", command, err)
+	}
+
+	var resp StatusResponse
+	if err := decoder.Decode(&resp); err != nil {
+		return nil, fmt.Errorf("failed to decode daemon response: %w", err)
+	}
+	return &resp, nil
+}
+
+// QueryStatus contacts the daemon control socket for a status snapshot.
+func QueryStatus(ctx context.Context, paths Paths) (*StatusResponse, error) {
+	return sendRequest(ctx, paths, "status")
+}
+
+// SendStop requests the daemon to initiate shutdown.
+func SendStop(ctx context.Context, paths Paths) (*StatusResponse, error) {
+	return sendRequest(ctx, paths, "stop")
+}

--- a/daemon/paths.go
+++ b/daemon/paths.go
@@ -1,0 +1,43 @@
+package daemon
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+// Paths represents the filesystem anchor for daemon metadata.
+type Paths struct {
+	RuntimeDir string
+	PIDFile    string
+	SocketFile string
+	LogFile    string
+}
+
+// ResolvePaths determines the directory for daemon runtime artifacts and ensures it exists.
+func ResolvePaths() (Paths, error) {
+	runtimeDir := os.Getenv("XDG_RUNTIME_DIR")
+	if runtimeDir != "" {
+		runtimeDir = filepath.Join(runtimeDir, "tunn")
+	} else {
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return Paths{}, fmt.Errorf("failed to determine home directory: %w", err)
+		}
+		runtimeDir = filepath.Join(home, ".cache", "tunn")
+	}
+
+	if err := os.MkdirAll(runtimeDir, 0o700); err != nil {
+		return Paths{}, fmt.Errorf("failed to create runtime directory: %w", err)
+	}
+	if err := os.Chmod(runtimeDir, 0o700); err != nil && !os.IsPermission(err) {
+		return Paths{}, fmt.Errorf("failed to enforce runtime directory permissions: %w", err)
+	}
+
+	return Paths{
+		RuntimeDir: runtimeDir,
+		PIDFile:    filepath.Join(runtimeDir, "daemon.pid"),
+		SocketFile: filepath.Join(runtimeDir, "daemon.sock"),
+		LogFile:    filepath.Join(runtimeDir, "daemon.log"),
+	}, nil
+}

--- a/daemon/pid.go
+++ b/daemon/pid.go
@@ -1,0 +1,78 @@
+package daemon
+
+import (
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+)
+
+// ReadPID loads the stored daemon PID if present.
+func ReadPID(paths Paths) (int, error) {
+	data, err := os.ReadFile(paths.PIDFile)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return 0, nil
+		}
+		return 0, fmt.Errorf("failed to read pid file: %w", err)
+	}
+
+	text := strings.TrimSpace(string(data))
+	if text == "" {
+		return 0, nil
+	}
+
+	pid, err := strconv.Atoi(text)
+	if err != nil {
+		return 0, fmt.Errorf("invalid pid file contents: %w", err)
+	}
+	return pid, nil
+}
+
+// WritePID persists the daemon PID with restrictive permissions.
+func WritePID(paths Paths, pid int) error {
+	content := []byte(strconv.Itoa(pid) + "\n")
+	if err := os.WriteFile(paths.PIDFile, content, 0o600); err != nil {
+		return fmt.Errorf("failed to write pid file: %w", err)
+	}
+	return nil
+}
+
+// RemovePID clears the stored PID file if present.
+func RemovePID(paths Paths) error {
+	if err := os.Remove(paths.PIDFile); err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("failed to remove pid file: %w", err)
+	}
+	return nil
+}
+
+// RemoveSocket unlinks the daemon's control socket.
+func RemoveSocket(paths Paths) error {
+	if err := os.Remove(paths.SocketFile); err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("failed to remove socket: %w", err)
+	}
+	return nil
+}
+
+// Cleanup removes daemon runtime files.
+func Cleanup(paths Paths) {
+	_ = RemovePID(paths)
+	_ = RemoveSocket(paths)
+}
+
+// CheckRunning inspects the pid file and returns the running state.
+func CheckRunning(paths Paths) (pid int, running bool, err error) {
+	pid, err = ReadPID(paths)
+	if err != nil {
+		return 0, false, err
+	}
+	if pid == 0 {
+		return 0, false, nil
+	}
+	if isProcessRunning(pid) {
+		return pid, true, nil
+	}
+
+	Cleanup(paths)
+	return 0, false, nil
+}

--- a/daemon/pid_unix_test.go
+++ b/daemon/pid_unix_test.go
@@ -1,0 +1,67 @@
+//go:build unix
+
+package daemon
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestPIDLifecycle(t *testing.T) {
+	dir := t.TempDir()
+	paths := Paths{
+		RuntimeDir: dir,
+		PIDFile:    filepath.Join(dir, "daemon.pid"),
+		SocketFile: filepath.Join(dir, "daemon.sock"),
+	}
+
+	if err := WritePID(paths, os.Getpid()); err != nil {
+		t.Fatalf("WritePID failed: %v", err)
+	}
+
+	pid, err := ReadPID(paths)
+	if err != nil {
+		t.Fatalf("ReadPID failed: %v", err)
+	}
+	if pid != os.Getpid() {
+		t.Fatalf("expected pid %d, got %d", os.Getpid(), pid)
+	}
+
+	pid, running, err := CheckRunning(paths)
+	if err != nil {
+		t.Fatalf("CheckRunning failed: %v", err)
+	}
+	if !running {
+		t.Fatalf("expected current process to be considered running")
+	}
+	if pid != os.Getpid() {
+		t.Fatalf("expected pid %d, got %d", os.Getpid(), pid)
+	}
+
+	// Write a clearly invalid PID.
+	if err := WritePID(paths, 999999); err != nil {
+		t.Fatalf("WritePID failed: %v", err)
+	}
+	if err := os.WriteFile(paths.SocketFile, []byte("stub"), 0o600); err != nil {
+		t.Fatalf("failed to write socket stub: %v", err)
+	}
+
+	pid, running, err = CheckRunning(paths)
+	if err != nil {
+		t.Fatalf("CheckRunning failed: %v", err)
+	}
+	if running {
+		t.Fatalf("expected stale pid to be treated as not running")
+	}
+	if pid != 0 {
+		t.Fatalf("expected pid to be cleared, got %d", pid)
+	}
+
+	if _, err := os.Stat(paths.PIDFile); !os.IsNotExist(err) {
+		t.Fatalf("expected pid file to be removed, got err %v", err)
+	}
+	if _, err := os.Stat(paths.SocketFile); !os.IsNotExist(err) {
+		t.Fatalf("expected socket file to be removed, got err %v", err)
+	}
+}

--- a/daemon/process_other.go
+++ b/daemon/process_other.go
@@ -1,0 +1,7 @@
+//go:build !unix
+
+package daemon
+
+func isProcessRunning(pid int) bool {
+	return false
+}

--- a/daemon/process_unix.go
+++ b/daemon/process_unix.go
@@ -1,0 +1,16 @@
+//go:build unix
+
+package daemon
+
+import "syscall"
+
+func isProcessRunning(pid int) bool {
+	if pid <= 0 {
+		return false
+	}
+	err := syscall.Kill(pid, 0)
+	if err == nil {
+		return true
+	}
+	return err == syscall.EPERM
+}

--- a/daemon/server.go
+++ b/daemon/server.go
@@ -1,0 +1,148 @@
+package daemon
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net"
+	"os"
+	"sync"
+
+	"github.com/strandnerd/tunn/status"
+)
+
+// StatusRequest represents an IPC command from the CLI.
+type StatusRequest struct {
+	Command string `json:"command"`
+}
+
+// StatusResponse captures the daemon state for CLI consumption.
+type StatusResponse struct {
+	Running bool            `json:"running"`
+	Mode    string          `json:"mode"`
+	PID     int             `json:"pid"`
+	Message string          `json:"message,omitempty"`
+	Tunnels []status.Tunnel `json:"tunnels,omitempty"`
+}
+
+// Server handles IPC communication with CLI clients.
+type Server struct {
+	paths  Paths
+	store  *status.Store
+	pid    int
+	mu     sync.Mutex
+	ln     net.Listener
+	stopFn func()
+}
+
+// NewServer constructs a server bound to the given socket and status store.
+func NewServer(paths Paths, store *status.Store, pid int, stopFn func()) *Server {
+	return &Server{
+		paths:  paths,
+		store:  store,
+		pid:    pid,
+		stopFn: stopFn,
+	}
+}
+
+// Run starts the IPC server and blocks until the context is cancelled or the listener fails.
+func (s *Server) Run(ctx context.Context) error {
+	if err := os.Remove(s.paths.SocketFile); err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("failed to remove existing socket: %w", err)
+	}
+
+	ln, err := net.Listen("unix", s.paths.SocketFile)
+	if err != nil {
+		return fmt.Errorf("failed to listen on socket: %w", err)
+	}
+	if err := os.Chmod(s.paths.SocketFile, 0o600); err != nil {
+		ln.Close()
+		return fmt.Errorf("failed to secure socket permissions: %w", err)
+	}
+
+	s.mu.Lock()
+	s.ln = ln
+	s.mu.Unlock()
+
+	defer func() {
+		ln.Close()
+		_ = os.Remove(s.paths.SocketFile)
+	}()
+
+	go func() {
+		<-ctx.Done()
+		s.Close()
+	}()
+
+	for {
+		conn, err := ln.Accept()
+		if err != nil {
+			select {
+			case <-ctx.Done():
+				return nil
+			default:
+			}
+			if errors.Is(err, net.ErrClosed) {
+				return nil
+			}
+			return err
+		}
+		go s.handleConnection(conn)
+	}
+}
+
+// Close terminates the listener if active.
+func (s *Server) Close() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.ln != nil {
+		_ = s.ln.Close()
+		s.ln = nil
+	}
+}
+
+func (s *Server) handleConnection(conn net.Conn) {
+	defer conn.Close()
+	decoder := json.NewDecoder(conn)
+	var req StatusRequest
+	if err := decoder.Decode(&req); err != nil {
+		return
+	}
+
+	switch req.Command {
+	case "status":
+		s.handleStatus(conn)
+	case "stop":
+		s.handleStop(conn)
+	default:
+		return
+	}
+}
+
+func (s *Server) handleStatus(conn net.Conn) {
+	encoder := json.NewEncoder(conn)
+	snapshot := s.store.Snapshot()
+	resp := StatusResponse{
+		Running: true,
+		Mode:    "daemon",
+		PID:     s.pid,
+		Tunnels: snapshot,
+	}
+	_ = encoder.Encode(resp)
+}
+
+func (s *Server) handleStop(conn net.Conn) {
+	encoder := json.NewEncoder(conn)
+	resp := StatusResponse{
+		Running: false,
+		Mode:    "daemon",
+		PID:     s.pid,
+		Message: "stopping",
+		Tunnels: s.store.Snapshot(),
+	}
+	_ = encoder.Encode(resp)
+	if s.stopFn != nil {
+		s.stopFn()
+	}
+}

--- a/daemon/server_test.go
+++ b/daemon/server_test.go
@@ -1,0 +1,103 @@
+package daemon
+
+import (
+	"encoding/json"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/strandnerd/tunn/status"
+)
+
+func TestServerStatusHandshake(t *testing.T) {
+	store := status.NewStore()
+	store.EnsureTunnel("db", []string{"5432"})
+	store.Update("db", "5432", "active")
+
+	s := NewServer(Paths{}, store, 1234, nil)
+	clientConn, serverConn := net.Pipe()
+	t.Cleanup(func() {
+		clientConn.Close()
+	})
+
+	done := make(chan struct{})
+	go func() {
+		s.handleConnection(serverConn)
+		close(done)
+	}()
+
+	enc := json.NewEncoder(clientConn)
+	dec := json.NewDecoder(clientConn)
+
+	if err := enc.Encode(StatusRequest{Command: "status"}); err != nil {
+		t.Fatalf("failed to encode request: %v", err)
+	}
+
+	var resp StatusResponse
+	if err := dec.Decode(&resp); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+
+	<-done
+
+	if !resp.Running {
+		t.Fatalf("expected running status, got %+v", resp)
+	}
+	if resp.Mode != "daemon" {
+		t.Fatalf("expected mode daemon, got %s", resp.Mode)
+	}
+	if resp.PID != 1234 {
+		t.Fatalf("expected pid 1234, got %d", resp.PID)
+	}
+	if len(resp.Tunnels) != 1 {
+		t.Fatalf("expected 1 tunnel in response, got %d", len(resp.Tunnels))
+	}
+	if resp.Tunnels[0].Ports["5432"] != "active" {
+		t.Fatalf("expected port status active, got %s", resp.Tunnels[0].Ports["5432"])
+	}
+}
+
+func TestServerStopCommand(t *testing.T) {
+	store := status.NewStore()
+	store.EnsureTunnel("db", []string{"5432"})
+	triggered := make(chan struct{}, 1)
+
+	s := NewServer(Paths{}, store, 99, func() {
+		triggered <- struct{}{}
+	})
+
+	clientConn, serverConn := net.Pipe()
+	t.Cleanup(func() {
+		clientConn.Close()
+	})
+
+	go s.handleConnection(serverConn)
+
+	enc := json.NewEncoder(clientConn)
+	dec := json.NewDecoder(clientConn)
+
+	if err := enc.Encode(StatusRequest{Command: "stop"}); err != nil {
+		t.Fatalf("failed to encode request: %v", err)
+	}
+
+	var resp StatusResponse
+	if err := dec.Decode(&resp); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+
+	if resp.Running {
+		t.Fatalf("expected running=false response, got %+v", resp)
+	}
+	if resp.PID != 99 {
+		t.Fatalf("expected pid 99, got %d", resp.PID)
+	}
+	if resp.Message != "stopping" {
+		t.Fatalf("expected message 'stopping', got %q", resp.Message)
+	}
+
+	select {
+	case <-triggered:
+	case <-time.After(100 * time.Millisecond):
+		t.Fatalf("expected stop callback to be invoked")
+	}
+}

--- a/daemon/wait.go
+++ b/daemon/wait.go
@@ -1,0 +1,24 @@
+package daemon
+
+import (
+	"errors"
+	"os"
+	"time"
+)
+
+// WaitForSocket waits for the daemon to create its control socket within the timeout.
+func WaitForSocket(paths Paths, timeout time.Duration) error {
+	deadline := time.Now().Add(timeout)
+	for {
+		if _, err := os.Stat(paths.SocketFile); err == nil {
+			return nil
+		} else if !errors.Is(err, os.ErrNotExist) {
+			return err
+		}
+
+		if time.Now().After(deadline) {
+			return errors.New("daemon did not create control socket in time")
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+}

--- a/main.go
+++ b/main.go
@@ -2,14 +2,24 @@ package main
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"log"
 	"os"
+	"os/exec"
 	"os/signal"
+	"sort"
+	"strings"
+	"sync"
 	"syscall"
+	"time"
 
+	"github.com/strandnerd/tunn/cli"
 	"github.com/strandnerd/tunn/config"
+	"github.com/strandnerd/tunn/daemon"
 	"github.com/strandnerd/tunn/executor"
 	"github.com/strandnerd/tunn/output"
+	"github.com/strandnerd/tunn/status"
 	"github.com/strandnerd/tunn/tunnel"
 )
 
@@ -21,25 +31,144 @@ func main() {
 }
 
 func run() error {
+	args := os.Args[1:]
+
+	opts, err := cli.Parse(args)
+	if err != nil {
+		return err
+	}
+
+	paths, err := daemon.ResolvePaths()
+	if err != nil {
+		return err
+	}
+
+	switch opts.Command {
+	case cli.CommandStatus:
+		return runStatusCommand(paths)
+	case cli.CommandStop:
+		return runStopCommand(paths)
+	case cli.CommandStart:
+		if opts.InternalDaemon {
+			return runDaemonCommand(paths, opts.TunnelNames)
+		}
+		return runStartCommand(paths, opts)
+	default:
+		return fmt.Errorf("unknown command")
+	}
+}
+
+func runStartCommand(paths daemon.Paths, opts *cli.Options) error {
+	pid, running, err := daemon.CheckRunning(paths)
+	if err != nil {
+		return err
+	}
+	if running {
+		return fmt.Errorf("tunn daemon already running (pid %d); use 'tunn status' to inspect or stop it before launching in the foreground", pid)
+	}
+
 	cfg, err := config.Load()
 	if err != nil {
 		return err
 	}
 
-	selectedTunnels := cfg.FilterTunnels(os.Args[1:])
-
-	if len(selectedTunnels) == 0 {
-		if len(os.Args) > 1 {
-			return fmt.Errorf("no tunnels found matching: %v", os.Args[1:])
+	selected := cfg.FilterTunnels(opts.TunnelNames)
+	if len(selected) == 0 {
+		if len(opts.TunnelNames) > 0 {
+			return fmt.Errorf("no tunnels found matching: %v", opts.TunnelNames)
 		}
 		return fmt.Errorf("no tunnels defined in configuration")
 	}
 
+	if opts.Detach {
+		return launchDaemon(paths, opts.TunnelNames)
+	}
+
+	return runForeground(selected)
+}
+
+func launchDaemon(paths daemon.Paths, tunnelNames []string) error {
+	pid, running, err := daemon.CheckRunning(paths)
+	if err != nil {
+		return err
+	}
+	if running {
+		return fmt.Errorf("tunn daemon already running (pid %d); use 'tunn status' or stop it before relaunching", pid)
+	}
+
+	executable, err := os.Executable()
+	if err != nil {
+		return fmt.Errorf("failed to locate executable: %w", err)
+	}
+
+	args := []string{"--internal-daemon"}
+	args = append(args, tunnelNames...)
+
+	cmd := exec.Command(executable, args...)
+	cmd.Env = os.Environ()
+
+	logFile, err := os.OpenFile(paths.LogFile, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o600)
+	if err != nil {
+		return fmt.Errorf("failed to open daemon log: %w", err)
+	}
+	defer logFile.Close()
+	cmd.Stdout = logFile
+	cmd.Stderr = logFile
+
+	if err := cmd.Start(); err != nil {
+		return fmt.Errorf("failed to start daemon: %w", err)
+	}
+
+	childPID := cmd.Process.Pid
+	if err := daemon.WritePID(paths, childPID); err != nil {
+		_ = cmd.Process.Kill()
+		_, _ = cmd.Process.Wait()
+		return err
+	}
+
+	if err := daemon.WaitForSocket(paths, 3*time.Second); err != nil {
+		_ = cmd.Process.Kill()
+		_, _ = cmd.Process.Wait()
+		daemon.Cleanup(paths)
+		return fmt.Errorf("daemon failed to expose control socket: %w", err)
+	}
+
+	statusCtx, cancelStatus := context.WithTimeout(context.Background(), 500*time.Millisecond)
+	defer cancelStatus()
+	resp, statusErr := daemon.QueryStatus(statusCtx, paths)
+	if statusErr != nil || resp == nil || !resp.Running {
+		_ = cmd.Process.Kill()
+		_, _ = cmd.Process.Wait()
+		daemon.Cleanup(paths)
+		if statusErr != nil {
+			msg, logErr := tailLogMessage(paths.LogFile)
+			if logErr == nil && msg != "" {
+				return fmt.Errorf("daemon failed to start: %s", msg)
+			}
+			return fmt.Errorf("daemon failed to start: %w", statusErr)
+		}
+		return fmt.Errorf("daemon failed to start")
+	}
+
+	if err := cmd.Process.Release(); err != nil {
+		fmt.Fprintf(os.Stderr, "warning: failed to release daemon process: %v\n", err)
+	}
+
+	fmt.Printf("tunn daemon started (pid %d)\n", childPID)
+	return nil
+}
+
+func runForeground(tunnels map[string]config.Tunnel) error {
 	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	var shutdownOnce sync.Once
+	shutdown := func() {
+		shutdownOnce.Do(cancel)
+	}
+	defer shutdown()
 
 	sigChan := make(chan os.Signal, 1)
 	signal.Notify(sigChan, os.Interrupt, syscall.SIGTERM)
+	defer signal.Stop(sigChan)
 	go func() {
 		<-sigChan
 		fmt.Println("\nShutting down tunnels...")
@@ -54,5 +183,210 @@ func run() error {
 
 	manager := tunnel.NewManager(sshExec, display)
 
-	return manager.RunTunnels(ctx, selectedTunnels)
+	return manager.RunTunnels(ctx, tunnels)
+}
+
+func runDaemonCommand(paths daemon.Paths, tunnelNames []string) error {
+	cfg, err := config.Load()
+	if err != nil {
+		return err
+	}
+
+	selected := cfg.FilterTunnels(tunnelNames)
+	if len(selected) == 0 {
+		if len(tunnelNames) > 0 {
+			return fmt.Errorf("no tunnels found matching: %v", tunnelNames)
+		}
+		return fmt.Errorf("no tunnels defined in configuration")
+	}
+
+	logFile, err := os.OpenFile(paths.LogFile, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o600)
+	if err != nil {
+		return fmt.Errorf("failed to open daemon log: %w", err)
+	}
+	defer logFile.Close()
+
+	logger := log.New(logFile, "", log.LstdFlags)
+	logger.Printf("tunn daemon starting (pid %d)", os.Getpid())
+
+	store := status.NewStore()
+	for name, tun := range selected {
+		store.EnsureTunnel(name, tun.Ports)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	var shutdownOnce sync.Once
+	shutdown := func() {
+		shutdownOnce.Do(cancel)
+	}
+	defer shutdown()
+
+	sigChan := make(chan os.Signal, 1)
+	signal.Notify(sigChan, os.Interrupt, syscall.SIGTERM)
+	defer signal.Stop(sigChan)
+
+	go func() {
+		sig := <-sigChan
+		logger.Printf("received signal %v, initiating shutdown", sig)
+		shutdown()
+	}()
+
+	server := daemon.NewServer(paths, store, os.Getpid(), shutdown)
+	serverErrCh := make(chan error, 1)
+	go func() {
+		serverErrCh <- server.Run(ctx)
+	}()
+
+	sshExec := &executor.RealSSHExecutor{
+		OnStatusChange: store.Update,
+	}
+
+	manager := tunnel.NewManager(sshExec, nil)
+	managerErrCh := make(chan error, 1)
+	go func() {
+		managerErrCh <- manager.RunTunnels(ctx, selected)
+	}()
+
+	var managerErr error
+	var srvErr error
+	managerDone := false
+	serverDone := false
+	cancelled := false
+	serverClosed := false
+
+	for !managerDone || !serverDone {
+		select {
+		case err := <-managerErrCh:
+			managerErr = err
+			managerDone = true
+		case err := <-serverErrCh:
+			srvErr = err
+			serverDone = true
+		}
+		if !cancelled {
+			shutdown()
+			cancelled = true
+		}
+		if !serverClosed {
+			server.Close()
+			serverClosed = true
+		}
+	}
+
+	daemon.Cleanup(paths)
+
+	if srvErr != nil && !errors.Is(srvErr, context.Canceled) {
+		logger.Printf("ipc server error: %v", srvErr)
+	}
+
+	if managerErr != nil && !errors.Is(managerErr, context.Canceled) {
+		logger.Printf("tunnel manager exited with error: %v", managerErr)
+		return managerErr
+	}
+
+	logger.Printf("tunn daemon stopped")
+	return nil
+}
+
+func runStatusCommand(paths daemon.Paths) error {
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	resp, err := daemon.QueryStatus(ctx, paths)
+	if err != nil {
+		pid, running, checkErr := daemon.CheckRunning(paths)
+		if checkErr != nil {
+			return fmt.Errorf("failed to check daemon status: %w", checkErr)
+		}
+		if running {
+			return fmt.Errorf("daemon (pid %d) is unreachable: %v", pid, err)
+		}
+		fmt.Println("tunn daemon not running")
+		return nil
+	}
+
+	state := "running"
+	if !resp.Running {
+		state = "stopped"
+	}
+	fmt.Printf("Daemon: %s (pid %d, mode %s)\n", state, resp.PID, resp.Mode)
+	if len(resp.Tunnels) == 0 {
+		fmt.Println("No tunnels managed by daemon")
+		return nil
+	}
+
+	sort.Slice(resp.Tunnels, func(i, j int) bool {
+		return resp.Tunnels[i].Name < resp.Tunnels[j].Name
+	})
+
+	fmt.Println("Tunnels:")
+	for _, tun := range resp.Tunnels {
+		fmt.Printf("  %s\n", tun.Name)
+		ports := make([]string, 0, len(tun.Ports))
+		for port := range tun.Ports {
+			ports = append(ports, port)
+		}
+		sort.Strings(ports)
+		for _, port := range ports {
+			fmt.Printf("    %s - %s\n", port, tun.Ports[port])
+		}
+	}
+
+	return nil
+}
+
+func runStopCommand(paths daemon.Paths) error {
+	pid, running, err := daemon.CheckRunning(paths)
+	if err != nil {
+		return err
+	}
+	if !running {
+		fmt.Println("tunn daemon not running")
+		return nil
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	resp, err := daemon.SendStop(ctx, paths)
+	if err != nil {
+		return fmt.Errorf("failed to send stop command: %w", err)
+	}
+
+	statusLine := fmt.Sprintf("stopping... (pid %d)", pid)
+	if resp.Message != "" && resp.Message != "stopping" {
+		statusLine = fmt.Sprintf("%s (%s)", statusLine, resp.Message)
+	}
+	fmt.Println(statusLine)
+
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		time.Sleep(100 * time.Millisecond)
+		_, stillRunning, checkErr := daemon.CheckRunning(paths)
+		if checkErr != nil {
+			return checkErr
+		}
+		if !stillRunning {
+			fmt.Println("tunn daemon stopped")
+			return nil
+		}
+	}
+
+	fmt.Println("tunn daemon stopping — run 'tunn status' to verify if needed")
+	return nil
+}
+
+func tailLogMessage(path string) (string, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return "", err
+	}
+	lines := strings.Split(strings.TrimSpace(string(data)), "\n")
+	for i := len(lines) - 1; i >= 0; i-- {
+		line := strings.TrimSpace(lines[i])
+		if line != "" {
+			return line, nil
+		}
+	}
+	return "", nil
 }

--- a/output/display.go
+++ b/output/display.go
@@ -39,6 +39,7 @@ type Display struct {
 	colorMap map[string]string
 	colorIdx int
 	printed  bool
+	footer   string
 }
 
 func NewDisplay() *Display {
@@ -137,6 +138,24 @@ func (d *Display) printStatuses() {
 		}
 		fmt.Println()
 	}
+
+	footer := strings.TrimSpace(d.footer)
+	if footer != "" {
+		fmt.Println(footer)
+	}
+}
+
+// SetFooter updates the message rendered beneath the tunnel table.
+func (d *Display) SetFooter(message string) {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+
+	trimmed := strings.TrimSpace(message)
+	if d.footer == trimmed {
+		return
+	}
+	d.footer = trimmed
+	d.printStatuses()
 }
 
 func (d *Display) PrintError(tunnelName string, message string) {

--- a/status/store.go
+++ b/status/store.go
@@ -1,0 +1,78 @@
+package status
+
+import "sync"
+
+// Tunnel represents the status of a single tunnel and its ports.
+type Tunnel struct {
+	Name  string
+	Ports map[string]string
+}
+
+// Store keeps track of tunnel status updates for IPC consumers.
+type Store struct {
+	mu      sync.RWMutex
+	tunnels map[string]*Tunnel
+}
+
+// NewStore creates an empty status store ready for updates.
+func NewStore() *Store {
+	return &Store{
+		tunnels: make(map[string]*Tunnel),
+	}
+}
+
+// EnsureTunnel pre-populates entries for a tunnel and its ports.
+func (s *Store) EnsureTunnel(name string, ports []string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	tun, exists := s.tunnels[name]
+	if !exists {
+		tun = &Tunnel{
+			Name:  name,
+			Ports: make(map[string]string),
+		}
+		s.tunnels[name] = tun
+	}
+
+	for _, port := range ports {
+		if _, ok := tun.Ports[port]; !ok {
+			tun.Ports[port] = "pending"
+		}
+	}
+}
+
+// Update records a status change for a tunnel port.
+func (s *Store) Update(name string, port string, state string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	tun, exists := s.tunnels[name]
+	if !exists {
+		tun = &Tunnel{
+			Name:  name,
+			Ports: make(map[string]string),
+		}
+		s.tunnels[name] = tun
+	}
+	tun.Ports[port] = state
+}
+
+// Snapshot returns a copy of the current tunnel states suitable for external use.
+func (s *Store) Snapshot() []Tunnel {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	result := make([]Tunnel, 0, len(s.tunnels))
+	for _, tun := range s.tunnels {
+		clone := Tunnel{
+			Name:  tun.Name,
+			Ports: make(map[string]string, len(tun.Ports)),
+		}
+		for port, state := range tun.Ports {
+			clone.Ports[port] = state
+		}
+		result = append(result, clone)
+	}
+	return result
+}

--- a/status/store_test.go
+++ b/status/store_test.go
@@ -1,0 +1,40 @@
+package status
+
+import "testing"
+
+func TestStore(t *testing.T) {
+	s := NewStore()
+	s.EnsureTunnel("db", []string{"5432", "5433"})
+	s.Update("db", "5432", "active")
+	s.Update("cache", "6379", "connecting")
+
+	snapshot := s.Snapshot()
+	if len(snapshot) != 2 {
+		t.Fatalf("expected 2 tunnels, got %d", len(snapshot))
+	}
+
+	// Ensure copies are independent
+	snapshot[0].Ports["5432"] = "mutated"
+
+	snapshot2 := s.Snapshot()
+	for _, tun := range snapshot2 {
+		if tun.Name == "db" {
+			state, ok := tun.Ports["5432"]
+			if !ok {
+				t.Fatalf("expected db:5432 to exist")
+			}
+			if state != "active" {
+				t.Fatalf("expected db:5432 to be active, got %q", state)
+			}
+		}
+		if tun.Name == "cache" {
+			state, ok := tun.Ports["6379"]
+			if !ok {
+				t.Fatalf("expected cache:6379 to exist")
+			}
+			if state != "connecting" {
+				t.Fatalf("expected cache:6379 to be connecting, got %q", state)
+			}
+		}
+	}
+}

--- a/tunnel/manager_test.go
+++ b/tunnel/manager_test.go
@@ -28,7 +28,7 @@ func (s *stubPortChecker) findListener(port string) (*processInfo, error) {
 func TestManagerRunTunnels(t *testing.T) {
 	mock := &executor.MockSSHExecutor{}
 	display := output.NewDisplay()
-	manager := NewManager(mock, display)
+	manager := NewManager(mock, display, nil)
 	manager.checker = &stubPortChecker{}
 
 	tunnels := map[string]config.Tunnel{
@@ -71,7 +71,7 @@ func TestManagerRunTunnels(t *testing.T) {
 func TestManagerRunSingleTunnel(t *testing.T) {
 	mock := &executor.MockSSHExecutor{}
 	display := output.NewDisplay()
-	manager := NewManager(mock, display)
+	manager := NewManager(mock, display, nil)
 	manager.checker = &stubPortChecker{}
 
 	tunnels := map[string]config.Tunnel{
@@ -112,7 +112,7 @@ func TestManagerRunSingleTunnel(t *testing.T) {
 func TestManagerCancellation(t *testing.T) {
 	mock := &executor.MockSSHExecutor{}
 	display := output.NewDisplay()
-	manager := NewManager(mock, display)
+	manager := NewManager(mock, display, nil)
 	manager.checker = &stubPortChecker{}
 
 	tunnels := map[string]config.Tunnel{
@@ -138,7 +138,7 @@ func TestManagerCancellation(t *testing.T) {
 func TestManagerRunTunnelPortInUse(t *testing.T) {
 	mock := &executor.MockSSHExecutor{}
 	display := output.NewDisplay()
-	manager := NewManager(mock, display)
+	manager := NewManager(mock, display, nil)
 	manager.checker = &stubPortChecker{
 		listeners: map[string]*processInfo{
 			"3000": {

--- a/tunnel/manager_test.go
+++ b/tunnel/manager_test.go
@@ -89,8 +89,23 @@ func TestManagerRunSingleTunnel(t *testing.T) {
 		t.Errorf("Expected context deadline exceeded, got %v", err)
 	}
 
-	if len(mock.Commands) != 2 {
-		t.Errorf("Expected 2 commands (one per port), got %d", len(mock.Commands))
+	if len(mock.Commands) != 1 {
+		t.Fatalf("Expected 1 command for tunnel, got %d", len(mock.Commands))
+	}
+
+	cmd := mock.Commands[0]
+	found3000 := false
+	found4000 := false
+	for i := 0; i < len(cmd)-1; i++ {
+		if cmd[i] == "-L" && cmd[i+1] == "3000:localhost:3000" {
+			found3000 = true
+		}
+		if cmd[i] == "-L" && cmd[i+1] == "4000:localhost:4000" {
+			found4000 = true
+		}
+	}
+	if !found3000 || !found4000 {
+		t.Fatalf("expected aggregated command to include both port mappings, got %v", cmd)
 	}
 }
 


### PR DESCRIPTION
  # Summary

  - introduce a background daemon that supervises all configured tunnels and exposes an IPC socket for CLI commands
  - add `tunn start -d` to spawn the daemon, write PID/socket/log files under XDG runtime (or ~/.cache/tunn), and validate startup health before returning
  - add tunn status to query the daemon, rendering a live ANSI dashboard in terminals or plain text for scripts
  - add tunn stop to request a graceful daemon shutdown, waiting briefly for completion
  - reuse the existing tunnel manager with a new notifier hook so both foreground and daemon modes share runtime logic and per-port status tracking
  - document the new workflow (daemon lifecycle commands, single dependency on gopkg.in/yaml.v3, SSH-based execution, supported platforms) and add an AGENTS.md contributor guide
