### PR TITLE
feat: enable keepalive and exit of forward failure to ssh command

### DIFF
--- a/executor/executor.go
+++ b/executor/executor.go
@@ -47,7 +47,11 @@ func (e *RealSSHExecutor) Execute(ctx context.Context, name string, tunnel confi
 
 func (e *RealSSHExecutor) executePortSSH(ctx context.Context, tunnelName string, tunnel config.Tunnel, portMapping string) error {
 	// Build SSH command for this specific port
-	args := []string{"-N"}
+	args := []string{
+		"-o", "ServerAliveInterval=60",
+		"-o", "ExitOnForwardFailure=yes",
+		"-N",
+	}
 
 	ports := expandPort(portMapping, ":")
 	local, remote := ports[0], ports[1]
@@ -151,7 +155,13 @@ type MockSSHExecutor struct {
 }
 
 func (m *MockSSHExecutor) Execute(ctx context.Context, name string, tunnel config.Tunnel) error {
-	args := []string{"ssh", "-N"}
+	args := []string{
+		"ssh",
+		"-o", "ServerAliveInterval=60",
+		"-o", "ExitOnForwardFailure=yes",
+		"-N",
+	}
+
 	for _, portMapping := range tunnel.Ports {
 		ports := expandPort(portMapping, ":")
 		local, remote := ports[0], ports[1]

--- a/executor/executor_test.go
+++ b/executor/executor_test.go
@@ -32,8 +32,20 @@ func TestMockSSHExecutor(t *testing.T) {
 	cmd := mock.Commands[0]
 	cmdStr := strings.Join(cmd, " ")
 
-	if !strings.Contains(cmdStr, "ssh -N") {
-		t.Error("Command should contain 'ssh -N'")
+	if !strings.Contains(cmdStr, "ssh") {
+		t.Error("Command should contain 'ssh'")
+	}
+
+	if !strings.Contains(cmdStr, "-N") {
+		t.Error("Command should contain '-N'")
+	}
+
+	if !strings.Contains(cmdStr, "-o ServerAliveInterval=60") {
+		t.Error("Command should contain '-o ServerAliveInterval=60'")
+	}
+
+	if !strings.Contains(cmdStr, "-o ExitOnForwardFailure=yes") {
+		t.Error("Command should contain '-o ExitOnForwardFailure=yes'")
 	}
 
 	if !strings.Contains(cmdStr, "-L 8080:localhost:8080") {


### PR DESCRIPTION
This pull request updates the SSH client invocation to include two options that improve connection reliability and make port-forward setup fail fast on errors:

- ServerAliveInterval=60 — sends keepalive packets every 60 seconds to detect and recover broken connections more promptly.
- ExitOnForwardFailure=yes — causes the ssh client to exit immediately if any requested port forward (local, remote, or dynamic) cannot be established, preventing backgrounded sessions with missing forwards.

Why:
- Prevents long-lived but effectively dead SSH sessions by enabling timely detection of network drops.
- Avoids silent failures where port forwarding appears active while required tunnels never established, which can lead to subtle runtime errors.
